### PR TITLE
Feat: upgrade Grafana to latest stable version

### DIFF
--- a/docker/grafana-aws-env/Dockerfile
+++ b/docker/grafana-aws-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.2.4
+FROM grafana/grafana:5.4.3
 USER root
 RUN curl -L https://github.com/telia-oss/aws-env/releases/download/v0.3.0/aws-env-linux-amd64 > /usr/local/bin/aws-env && \
       echo f80addd4adf9aa8d4ecf1b16de402ba4  /usr/local/bin/aws-env | md5sum -c && \


### PR DESCRIPTION
Upgrade Grafana to `v5.4.3`
https://hub.docker.com/r/grafana/grafana/

Reasons: 

- Autofit feature

- AWS AppSync support